### PR TITLE
Fix performance issues on reinitializing

### DIFF
--- a/jquery.particleground.js
+++ b/jquery.particleground.js
@@ -344,7 +344,8 @@
     }
 
     function destroy() {
-      console.log('destroy');
+      pause();
+      particles = [];
       canvas.parentNode.removeChild(canvas);
       hook('onDestroy');
       if ($) {


### PR DESCRIPTION
Pause draw animation loop on destroy and garbage collect particles array of objects

This commit helps the plugin to garbage collect all particle objects on
destroy and also pauses the recurring draw animation loop that stayed
running after destroy - causing big performance issues when reinitializing the plugin without page refresh